### PR TITLE
Update link to badge schematic in software/README.md

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -1,3 +1,3 @@
 # Resources
 
-![Badge Schematic](resources/badge_photos/supercon8_sao_badge_featured.png)
+![Badge Schematic](hardware/Badge_2024_schematic.jpg)

--- a/software/README.md
+++ b/software/README.md
@@ -1,3 +1,3 @@
 # Resources
 
-![Badge Schematic](hardware/Badge_2024_schematic.jpg)
+![Badge Schematic](/hardware/Badge_2024_schematic.jpg)

--- a/software/README.md
+++ b/software/README.md
@@ -1,3 +1,4 @@
 # Resources
 
+## Badge Schematic
 ![Badge Schematic](/hardware/Badge_2024_schematic.jpg)


### PR DESCRIPTION
README.md in the /software folder includes a link for the badge schematic but it references an image that (a) is of the badge itself not the badge schematic and (b) links to a file location in the repo that doesn't exist.  This adjusts that link to point to the badge schematic in the current version of the repo (in /hardware). and adds a subsection heading to the README to specifically call out that it is the badge schematic.

Nothing major, but if I'm going to propose other additions (e.g. software libraries to incorporate) it's good to test out my fork/PR setup beforehand.

Thanks for all this great work, and look forward to seeing you at Supercon 8.